### PR TITLE
Gotpl 1.24

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -40,5 +40,7 @@ COPY --from=build --chown=wodby:wodby /app/build web/
 
 # Update & upgrade packages to prevent vulnerabilities
 RUN apk update && apk upgrade
+RUN gotpl_url="https://github.com/wodby/gotpl/releases/latest/download/gotpl-${TARGETPLATFORM/\//-}.tar.gz"; \
+wget -O- "${gotpl_url}" | tar xz --no-same-owner -C /usr/local/bin;
 
 USER wodby

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -39,8 +39,9 @@ WORKDIR /var/www/html
 COPY --from=build --chown=wodby:wodby /app/build web/
 
 # Update & upgrade packages to prevent vulnerabilities
+# https://github.com/wodby/gotpl/releases/
 RUN apk update && apk upgrade
-RUN gotpl_url="https://github.com/wodby/gotpl/releases/latest/download/gotpl-${TARGETPLATFORM/\//-}.tar.gz"; \
+RUN gotpl_url="https://github.com/wodby/gotpl/releases/latest/download/gotpl-linux-amd64.tar.gz"; \
 wget -O- "${gotpl_url}" | tar xz --no-same-owner -C /usr/local/bin;
 
 USER wodby


### PR DESCRIPTION
### What's Changed?

* Fetch latest `gotpl` from https://github.com/wodby/gotpl/releases/ for vuln fixes.